### PR TITLE
feat: clean_specific_sql

### DIFF
--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -161,6 +161,12 @@ module ActiveRecordCleanDbStructure
       if options[:specific_sql].present?
         dump << options[:specific_sql]
       end
+
+      if options[:clean_specific_sql].present?
+        options[:clean_specific_sql].each do |sql|
+          dump.gsub!(sql, '')
+        end
+      end
     end
 
     def order_column_definitions(source)


### PR DESCRIPTION
Добавил, чтобы удалять `SET transaction_timeout`

```ruby
  config.activerecord_clean_db_structure.clean_specific_sql = ["SET transaction_timeout = 0;\n"]
```